### PR TITLE
FEAT/criando-mensagens-erro-padronizadas

### DIFF
--- a/aplicacao/src/main/java/io/github/msimeaor/aplicacao/configuration/InternacionalizacaoConfig.java
+++ b/aplicacao/src/main/java/io/github/msimeaor/aplicacao/configuration/InternacionalizacaoConfig.java
@@ -1,0 +1,30 @@
+package io.github.msimeaor.aplicacao.configuration;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.Locale;
+
+@Configuration
+public class InternacionalizacaoConfig {
+
+  @Bean
+  public MessageSource messageSource() {
+    ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+    messageSource.setBasename("classpath:error-messages");
+    messageSource.setDefaultEncoding("ISO-8859-1");
+    messageSource.setDefaultLocale(Locale.getDefault());
+    return messageSource;
+  }
+
+  @Bean
+  public LocalValidatorFactoryBean validatorFactoryBean() {
+    LocalValidatorFactoryBean bean = new LocalValidatorFactoryBean();
+    bean.setValidationMessageSource(messageSource());
+    return bean;
+  }
+
+}


### PR DESCRIPTION
Criei um arquivo chamado error-messages.properties que conterá todas as mensagens de erro de validação dos DTOs

Criei dois beans que fazem a função de internacionalizar essas mensagens para o idioma do local da maquina do usuário e que permitem que eu use esses atributos no message das validações.