### PR TITLE
Ajustando problemas de serialização de objetos

### DIFF
--- a/aplicacao/pom.xml
+++ b/aplicacao/pom.xml
@@ -92,6 +92,16 @@
 			<artifactId>dozer-core</artifactId>
 			<version>6.4.1</version>
 		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/aplicacao/src/main/java/io/github/msimeaor/aplicacao/configuration/JacksonConfig.java
+++ b/aplicacao/src/main/java/io/github/msimeaor/aplicacao/configuration/JacksonConfig.java
@@ -1,0 +1,19 @@
+package io.github.msimeaor.aplicacao.configuration;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.findAndRegisterModules();
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    return objectMapper;
+  }
+
+}

--- a/aplicacao/src/main/java/io/github/msimeaor/aplicacao/model/service/impl/PessoaServiceImpl.java
+++ b/aplicacao/src/main/java/io/github/msimeaor/aplicacao/model/service/impl/PessoaServiceImpl.java
@@ -23,6 +23,7 @@ public class PessoaServiceImpl {
     this.veiculoRepository = veiculoRepository;
   }
 
+  // TODO desenvolver regra de persistir telefone e endereço caso seja passado no pessoaRequest
   @Transactional
   public ResponseEntity<PessoaResponseDTO> save( PessoaRequestDTO pessoaRequest, String placa ) {
     if (nomePessoaExiste(pessoaRequest.getNome()) && placaCarroExiste(placa)) {


### PR DESCRIPTION
Adicionei essas duas dependencias ao POM.XML adicionei esse bean do ObjectMapper, que é a classe principal usada pelo Jackson para serializar e desserializar objetos.

Configurei o ObjectMapper para não incluir atributos nulos na serialização de objetos e adicionei esse modulo jsr310 para tratar as datas que são enviadas nas requests