### PR TITLE
Tratando exceção de EmptyList

### DIFF
--- a/aplicacao/src/main/java/io/github/msimeaor/aplicacao/controller/ExceptionHandlerController.java
+++ b/aplicacao/src/main/java/io/github/msimeaor/aplicacao/controller/ExceptionHandlerController.java
@@ -1,6 +1,7 @@
 package io.github.msimeaor.aplicacao.controller;
 
 import io.github.msimeaor.aplicacao.exceptions.ExceptionResponse;
+import io.github.msimeaor.aplicacao.exceptions.geral.EmptyListException;
 import io.github.msimeaor.aplicacao.exceptions.pessoa.PessoaConflictException;
 import io.github.msimeaor.aplicacao.exceptions.pessoa.PessoaNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -25,6 +26,11 @@ public class ExceptionHandlerController extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(PessoaNotFoundException.class)
   public ResponseEntity<ExceptionResponse> pessoaNotFound(Exception ex, WebRequest request) {
+    return criarExceptionResponseERetornarResponseEntity(HttpStatus.NOT_FOUND, ex, request);
+  }
+
+  @ExceptionHandler(EmptyListException.class)
+  public ResponseEntity<ExceptionResponse> emptyList(Exception ex, WebRequest request) {
     return criarExceptionResponseERetornarResponseEntity(HttpStatus.NOT_FOUND, ex, request);
   }
 

--- a/aplicacao/src/main/java/io/github/msimeaor/aplicacao/controller/PessoaRestController.java
+++ b/aplicacao/src/main/java/io/github/msimeaor/aplicacao/controller/PessoaRestController.java
@@ -44,7 +44,7 @@ public class PessoaRestController {
   ) {
 
     var sortDirection = "desc".equalsIgnoreCase(direction) ? Sort.Direction.DESC : Sort.Direction.ASC;
-    Pageable pageable = PageRequest.of(number, size, Sort.by(direction, "nome"));
+    Pageable pageable = PageRequest.of(number, size, Sort.by(sortDirection, "nome"));
     return service.findAll( pageable );
   }
 

--- a/aplicacao/src/main/java/io/github/msimeaor/aplicacao/exceptions/geral/EmptyListException.java
+++ b/aplicacao/src/main/java/io/github/msimeaor/aplicacao/exceptions/geral/EmptyListException.java
@@ -1,0 +1,9 @@
+package io.github.msimeaor.aplicacao.exceptions.geral;
+
+public class EmptyListException extends RuntimeException {
+
+  public EmptyListException(String message) {
+    super(message);
+  }
+
+}

--- a/aplicacao/src/main/java/io/github/msimeaor/aplicacao/model/service/impl/PessoaServiceImpl.java
+++ b/aplicacao/src/main/java/io/github/msimeaor/aplicacao/model/service/impl/PessoaServiceImpl.java
@@ -1,6 +1,7 @@
 package io.github.msimeaor.aplicacao.model.service.impl;
 
 import io.github.msimeaor.aplicacao.controller.PessoaRestController;
+import io.github.msimeaor.aplicacao.exceptions.geral.EmptyListException;
 import io.github.msimeaor.aplicacao.exceptions.pessoa.PessoaConflictException;
 import io.github.msimeaor.aplicacao.exceptions.pessoa.PessoaNotFoundException;
 import io.github.msimeaor.aplicacao.mapper.DozerMapper;


### PR DESCRIPTION
Adicionei essa exception personalizada que é lançada sempre que uma busca retorna uma lista vazia. Para não retornar um array sem nada dentro, preferi criar a exception e retornar dizendo que não há registros cadastrados.